### PR TITLE
update $font-path

### DIFF
--- a/_sass/vendor/patternfly/_variables.scss
+++ b/_sass/vendor/patternfly/_variables.scss
@@ -50,7 +50,7 @@ $dropdown-link-hover-border-color:                                  $color-pf-bl
 $dropdown-link-focus-color:                                         $color-pf-white !default;
 $flyout-transition-pf:                                              all 200ms cubic-bezier(.35, 0, .25, 1) !default;
 $font-family-monospace:                                             Menlo, Monaco, Consolas, monospace !default;
-$font-path:                                                         if($pf-sass-asset-helper, "", "../fonts/") !default;
+$font-path:                                                         if($pf-sass-asset-helper, "", "../fonts/patternfly/") !default;
 $footer-pf-bg-color:                                                $color-pf-black !default;
 $footer-pf-padding-left:                                            25px !default;
 $footer-pf-padding-top:                                             10px !default;


### PR DESCRIPTION
The $font-path in _variables.scss looks incorrect. You can verify by just loading the default/root page (also seen at https://rh-uxd.github.io/design-tracker-template/) and looking in the browser console. 